### PR TITLE
Patch-1

### DIFF
--- a/src/Auth/Config.cs
+++ b/src/Auth/Config.cs
@@ -23,6 +23,9 @@ namespace Netsphere
         [JsonProperty("noob_mode")]
         public bool NoobMode { get; set; }
 
+        [JsonProperty("auto_register")]
+        public bool AutoRegister { get; set; }
+
         [JsonProperty("auth_database")]
         public DatabaseSettings AuthDatabase { get; set; }
 
@@ -44,6 +47,7 @@ namespace Netsphere
             MaxConnections = 100;
             WebAPI = new WebAPIConfig();
             NoobMode = true;
+            AutoRegister = false;
             AuthDatabase = new DatabaseSettings { Filename = "..\\db\\auth.db" };
         }
     }

--- a/src/Auth/Network/Service/AuthService.cs
+++ b/src/Auth/Network/Service/AuthService.cs
@@ -32,9 +32,9 @@ namespace Netsphere.Network.Service
 
             if (account == null)
             {
-                if (Config.Instance.NoobMode)
+                if (Config.Instance.NoobMode || Config.Instance.QuickAccount)
                 {
-                    // NoobMode: Create a new account if non exists
+                    // Create a new account if non exists
                     using (var scope = new DataAccessScope())
                     {
                         account = db.Accounts.Create();

--- a/src/Auth/Network/Service/AuthService.cs
+++ b/src/Auth/Network/Service/AuthService.cs
@@ -32,7 +32,7 @@ namespace Netsphere.Network.Service
 
             if (account == null)
             {
-                if (Config.Instance.NoobMode || Config.Instance.QuickAccount)
+                if (Config.Instance.NoobMode || Config.Instance.AutoRegister)
                 {
                     // Create a new account if non exists
                     using (var scope = new DataAccessScope())

--- a/src/Auth/Program.cs
+++ b/src/Auth/Program.cs
@@ -54,6 +54,13 @@ namespace Netsphere
                     .Write();
             }
 
+            if (Config.Instance.QuickAccount)
+            {
+                Logger.Warn()
+                    .Message("Quick Account is enabled. Accounts will be created for each new username received!")
+                    .Write();
+            }
+
             Console.CancelKeyPress += OnCancelKeyPress;
             while (true)
             {

--- a/src/Auth/Program.cs
+++ b/src/Auth/Program.cs
@@ -54,10 +54,10 @@ namespace Netsphere
                     .Write();
             }
 
-            if (Config.Instance.QuickAccount)
+            if (Config.Instance.AutoRegister)
             {
                 Logger.Warn()
-                    .Message("Quick Account is enabled. Accounts will be created for each new username received!")
+                    .Message("AutoRegister is enabled. Accounts will be created for each new username received!")
                     .Write();
             }
 

--- a/src/Game/Game/TeamManager.cs
+++ b/src/Game/Game/TeamManager.cs
@@ -34,14 +34,13 @@ namespace Netsphere.Game.Systems
         public void Add(Team team, uint playerLimit, uint spectatorLimit)
         {
             var playerTeam = new PlayerTeam(this, team, playerLimit, spectatorLimit);
-            if(!_teams.TryAdd(team, playerTeam))
+            if (!_teams.TryAdd(team, playerTeam))
                 throw new Exception($"Team {team} already exists");
         }
 
         public void Remove(Team team)
         {
             _teams.Remove(team);
-
         }
 
         public void Join(Player plr)
@@ -60,7 +59,7 @@ namespace Netsphere.Game.Systems
             teams[0].Join(plr);
         }
 
-        public void ChangeTeam(Player plr, Team team)
+        public void ChangeTeam(Player plr, Team team, bool report = true)
         {
             //if (plr.Room != Room)
             //throw new RoomException("Player is not inside this room");
@@ -76,7 +75,8 @@ namespace Netsphere.Game.Systems
 
             if (plr.RoomInfo.IsReady)
             {
-                plr.Session.Send(new SChangeTeamFailAckMessage(ChangeTeamResult.AlreadyReady));
+                if (report)
+                    plr.Session.Send(new SChangeTeamFailAckMessage(ChangeTeamResult.AlreadyReady));
                 throw new RoomException("Player is already ready");
             }
 
@@ -92,7 +92,8 @@ namespace Netsphere.Game.Systems
             }
             catch (TeamLimitReachedException)
             {
-                plr.Session.Send(new SChangeTeamFailAckMessage(ChangeTeamResult.Full));
+                if (report)
+                    plr.Session.Send(new SChangeTeamFailAckMessage(ChangeTeamResult.Full));
             }
         }
 

--- a/src/Game/Network/Services/AuthService.cs
+++ b/src/Game/Network/Services/AuthService.cs
@@ -163,6 +163,7 @@ namespace Netsphere.Network.Services
                     // first time connecting to this server
                     plrDto = GameDatabase.Instance.Players.Create((int)account.Id);
                     plrDto.Level = Config.Instance.Game.StartLevel;
+                    plrDto.TotalExperience = (int)GameServer.Instance.ResourceCache.GetExperience().ToList()[plrDto.Level].Value.TotalExperience;
                     plrDto.PEN = Config.Instance.Game.StartPEN;
                     plrDto.AP = Config.Instance.Game.StartAP;
                     plrDto.Coins1 = Config.Instance.Game.StartCoins1;

--- a/src/Game/Network/Services/GeneralService.cs
+++ b/src/Game/Network/Services/GeneralService.cs
@@ -14,5 +14,19 @@ namespace Netsphere.Network.Services
                 ServerTime = (uint)Program.AppTime.ElapsedMilliseconds
             });
         }
+
+        [MessageHandler(typeof(CQuickStartReqMessage))]
+        public void QuickStartHandler(GameSession session, CQuickStartReqMessage message)
+        {
+            //ToDo - Logic
+            session.Send(new SServerResultInfoAckMessage(ServerResult.FailedToRequestTask));
+        }
+
+        [MessageHandler(typeof(CTaskRequestReqMessage))]
+        public void TaskRequestHandler(GameSession session, CTaskRequestReqMessage message)
+        {
+            //ToDo - Logic
+            session.Send(new SServerResultInfoAckMessage(ServerResult.FailedToRequestTask));
+        }
     }
 }

--- a/src/Netsphere.Network/Extensions.cs
+++ b/src/Netsphere.Network/Extensions.cs
@@ -57,7 +57,9 @@ namespace Netsphere.Network
 
         public static float ReadCompressedFloat(this BinaryReader r)
         {
-            return r.ReadInt16().Decompress();
+            //Todo - This is a band-aid fix for stationary weapons
+            try { return r.ReadInt16().Decompress(); }
+            catch (EndOfStreamException) { return 0; }
         }
 
         public static Vector3 ReadCompressedVector3(this BinaryReader r)

--- a/src/Netsphere/Constants.cs
+++ b/src/Netsphere/Constants.cs
@@ -94,8 +94,8 @@
     {
         PEN = 1,
         AP = 2,
-        CP = 3,
-        None = 4
+        Premium = 3,
+        None = 4 // ToDo - CP?
     }
 
     public enum ItemPeriodType : uint


### PR DESCRIPTION
- Added a setting to create account on new usernames received on AuthServer
- Implemented Shuffle and Kick options on RoomService
- Temporary fix for stationary weapons (Netsphere.Network\Extencions.cs on ReadCompressedFloat -line 58)
- Added Premium as ItemPriceType constant
- CTaskRequestReqMessage and CQuickStartReqMessage send player a FailedToRequestTask message so the client doesn't stuck
- If a player is kicked from a room, he cannot join it back
- Master can move players between teams in a room
- Removed async from BuyItemHandler due to not been sending a response to client
- If the game server has set Minimum Level to a level greater than 0, a minimal Exp is added to the player referenced to the stated level.