### PR TITLE
Full Game timer "Fix"

### DIFF
--- a/src/Game/Constants.cs
+++ b/src/Game/Constants.cs
@@ -19,7 +19,9 @@ namespace Netsphere
         FirstHalf,
         EnteringHalfTime,
         HalfTime,
-        SecondHalf
+        SecondHalf,
+
+        FullGame
     }
 
     enum GameRuleStateTrigger

--- a/src/Game/Game/ChaserGameRule.cs
+++ b/src/Game/Game/ChaserGameRule.cs
@@ -1,0 +1,439 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Netsphere.Network.Message.GameRule;
+using NLog;
+
+// ReSharper disable once CheckNamespace
+namespace Netsphere.Game.GameRules
+{
+    internal class ChaserGameRule : GameRuleBase
+    {
+        private const uint PlayersNeededToStart = 2; // ToDo change to 4
+
+        private static readonly TimeSpan s_nextChaserWaitTime = TimeSpan.FromSeconds(8);
+        private readonly Random _random = new Random();
+
+        private TimeSpan _chaserRoundTime;
+        private TimeSpan _chaserTimer;
+        private TimeSpan _nextChaserTimer;
+
+        private bool _waitingNextChaser;
+        private Player _bonus;
+
+        public override GameRule GameRule => GameRule.Chaser;
+        public override Briefing Briefing { get; }
+
+        public Player Chaser { get; private set; }
+
+        public Player Bonus
+        {
+            get { return _bonus; }
+            private set
+            {
+                if (_bonus == value)
+                    return;
+                _bonus = value;
+                if (StateMachine.IsInState(GameRuleState.Playing))
+                    Room.Broadcast(new SChangeBonusTargetAckMessage(_bonus?.Account.Id ?? 0));
+            }
+        }
+
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public ChaserGameRule(Room room)
+            : base(room)
+        {
+            Briefing = new ChaserBriefing(this);
+
+            StateMachine.Configure(GameRuleState.Waiting)
+                .PermitIf(GameRuleStateTrigger.StartGame, GameRuleState.FullGame, CanStartGame);
+
+            StateMachine.Configure(GameRuleState.FullGame)
+                .SubstateOf(GameRuleState.Playing)
+                .Permit(GameRuleStateTrigger.StartResult, GameRuleState.EnteringResult)
+                .OnEntry(() =>
+                {
+                    _waitingNextChaser = true;
+                    NextChaser();
+                });
+
+            StateMachine.Configure(GameRuleState.EnteringResult)
+                .SubstateOf(GameRuleState.Playing)
+                .Permit(GameRuleStateTrigger.StartResult, GameRuleState.Result);
+
+            StateMachine.Configure(GameRuleState.Result)
+                .SubstateOf(GameRuleState.Playing)
+                .Permit(GameRuleStateTrigger.EndGame, GameRuleState.Waiting)
+                .OnEntry(() =>
+                {
+                    Bonus = null;
+                    Chaser = null;
+                });
+        }
+
+        public override void Initialize()
+        {
+            Room.TeamManager.Add(Team.Alpha, (uint)Room.Options.MatchKey.PlayerLimit, (uint)Room.Options.MatchKey.SpectatorLimit);
+            base.Initialize();
+        }
+
+        public override void Cleanup()
+        {
+            Room.TeamManager.Remove(Team.Alpha);
+            base.Cleanup();
+        }
+
+        public override void Update(TimeSpan delta)
+        {
+            base.Update(delta);
+
+            var teamMgr = Room.TeamManager;
+
+            if (StateMachine.IsInState(GameRuleState.Playing) &&
+                !StateMachine.IsInState(GameRuleState.EnteringResult) &&
+                !StateMachine.IsInState(GameRuleState.Result))
+            {
+                if (StateMachine.IsInState(GameRuleState.FullGame))
+                {
+                    // Still have enough players?
+                    if (teamMgr.PlayersPlaying.Count() < PlayersNeededToStart)
+                        StateMachine.Fire(GameRuleStateTrigger.StartResult);
+
+                    // Did we reach round limit?
+                    if (RoundTime >= Room.Options.TimeLimit)
+                        StateMachine.Fire(GameRuleStateTrigger.StartResult);
+
+                    // ToDo - Is the chaser inside this room?
+
+                    if (!_waitingNextChaser)
+                    {
+                        _chaserTimer += delta;
+                        if (_chaserTimer >= _chaserRoundTime)
+                        {
+                            ChaserLose();
+                        }
+
+                        if (!teamMgr.Values.Any(team => team.Values.Any(plr =>
+                                            plr != Chaser &&
+                                            plr.RoomInfo.Mode == PlayerGameMode.Normal &&
+                                            plr.RoomInfo.State != PlayerState.Dead)))
+                        {
+                            ChaserWin();
+                        }
+                    }
+                    else
+                    {
+                        _nextChaserTimer += delta;
+                        if (_nextChaserTimer >= s_nextChaserWaitTime)
+                            NextChaser();
+                    }
+                }
+            }
+        }
+
+        public override PlayerRecord GetPlayerRecord(Player plr)
+        {
+            return new ChaserPlayerRecord(plr);
+        }
+
+        public override void OnScoreKill(Player killer, Player assist, Player target, AttackAttribute attackAttribute)
+        {
+            if (target.RoomInfo.State == PlayerState.Waiting)
+                return;
+
+            if (target.RoomInfo.State == PlayerState.Alive)
+                target.RoomInfo.State = PlayerState.Dead;
+
+            var stats = GetRecord(killer);
+            stats.Kills++;
+
+            if (killer == Chaser && target == Bonus)
+            {
+                stats.BonusKills++;
+                GetBonusPlayer();
+            }
+
+            if (Chaser == target)
+            {
+                ChaserLose();
+            }
+
+            base.OnScoreKill(killer, null, target, attackAttribute);
+        }
+
+        public override void OnScoreSuicide(Player plr)
+        {
+            if (plr.RoomInfo.State == PlayerState.Waiting)
+                return;
+
+            if (plr.RoomInfo.State == PlayerState.Alive)
+                plr.RoomInfo.State = PlayerState.Dead;
+
+            if (Chaser == plr)
+            {
+                ChaserLose();
+            }
+
+            if (plr == Bonus)
+            {
+                GetRecord(Chaser).BonusKills++;
+                GetBonusPlayer();
+            }
+
+            base.OnScoreSuicide(plr);
+        }
+
+        //Triggered when attacking the chaser, it's value should fill the SCORE BAR
+        public virtual void OnChaserHit(Player chaser, Player attacker, float gunPoints, float meleePoints)
+        {
+            Logger.Info("[CSlaughterAttackPointReqMessage]-> Chaser " + chaser.Account.Nickname + " has been hit, attacked by " + attacker.Account.Nickname);
+            Logger.Info("GunPoints: " + gunPoints + " | MeleePoints: " + meleePoints);
+            //Room.Broadcast(new SSlaughterAttackPointAckMessage(chaser.Account.Id, gunPoints, meleePoints));
+        }
+
+        //Triggered when healing a friend, it's value should fill the SCORE BAR
+        public virtual void OnChaserHeal(Player healer, float healPoints)
+        {
+            Logger.Info("[CSlaughterHealPointReq] PLAYER: " + healer.Account.Nickname + " | HealPoints: " + healPoints);
+        }
+
+        public void NextChaser()
+        {
+            if (Chaser != null && !_waitingNextChaser)
+            {
+                foreach (var plr in Room.TeamManager.PlayersPlaying)
+                    plr.RoomInfo.State = PlayerState.Waiting;
+
+                _waitingNextChaser = true;
+                _nextChaserTimer = TimeSpan.Zero;
+                Room.Broadcast(new SEventMessageAckMessage(GameEventMessage.ChaserIn, (ulong)s_nextChaserWaitTime.TotalMilliseconds, 0, 0, ""));
+                return;
+            }
+
+            _chaserRoundTime = Room.Players.Count < 4 ? TimeSpan.FromSeconds(60) : TimeSpan.FromSeconds(Room.Players.Count * 15);
+            _chaserRoundTime += TimeSpan.FromSeconds(Chaser != null ? 3 : 6);
+
+            if (_chaserRoundTime + s_nextChaserWaitTime >= Room.Options.TimeLimit - RoundTime)
+            {
+                StateMachine.Fire(GameRuleStateTrigger.StartResult);
+                return;
+            }
+
+            _waitingNextChaser = false;
+
+            foreach (var plr in Room.TeamManager.PlayersPlaying)
+                plr.RoomInfo.State = PlayerState.Alive;
+
+            _chaserTimer = TimeSpan.Zero;
+            var index = _random.Next(0, Room.Players.Count);
+            Chaser = Room.Players.Values.ElementAt(index);
+            GetRecord(Chaser).ChaserCount++;
+            Room.Broadcast(new SChangeSlaughtererAckMessage(Chaser.Account.Id));
+            GetBonusPlayer();
+        }
+
+        public void ChaserWin()
+        {
+            GetRecord(Chaser).Wins++;
+            Room.Broadcast(new SScoreSLRoundWinAckMessage());
+            NextChaser();
+        }
+
+        public void ChaserLose()
+        {
+            foreach (var plr in GetPlayersAlive())
+                GetRecord(plr).Survived++;
+            Room.Broadcast(new SScoreRoundWinAckMessage());
+            NextChaser();
+        }
+
+        private bool CanStartGame()
+        {
+            if (!StateMachine.IsInState(GameRuleState.Waiting))
+                return false;
+
+            var countReady = Room.TeamManager.Values.Sum(team => team.Values.Count(plr => plr.RoomInfo.IsReady));
+            if (countReady < PlayersNeededToStart - 1) // Sum doesn't include master so decrease players needed by 1
+                return false;
+            return true;
+        }
+
+        private void GetBonusPlayer()
+        {
+            Bonus = GetPlayersAlive().OrderByDescending(player => player.RoomInfo.Stats.TotalScore).FirstOrDefault();
+        }
+
+        private IEnumerable<Player> GetPlayersAlive()
+        {
+            return Room.TeamManager.PlayersPlaying.Where(plr => plr != Chaser && plr.RoomInfo.State == PlayerState.Alive);
+        }
+
+        private static ChaserPlayerRecord GetRecord(Player plr)
+        {
+            return (ChaserPlayerRecord)plr.RoomInfo.Stats;
+        }
+    }
+
+    internal class ChaserBriefing : Briefing
+    {
+        public long CurrentChaser { get; set; }
+        public long CurrentChaserTarget { get; set; }
+
+        public int Unk3 { get; set; }
+        public int Unk4 { get; set; }
+        public int Unk5 { get; set; }
+        public int Unk6 { get; set; } //  *(_BYTE *)(v7 + 60) = v23 == 1;
+
+        public IList<int> Unk7 { get; set; }
+        public IList<long> Unk8 { get; set; }
+        public IList<long> Unk9 { get; set; }
+
+        public ChaserBriefing(GameRuleBase gameRule)
+            : base(gameRule)
+        {
+            Unk7 = new List<int>();
+            Unk8 = new List<long>();
+            Unk9 = new List<long>();
+        }
+
+        protected override void WriteData(BinaryWriter w, bool isResult)
+        {
+            base.WriteData(w, isResult);
+
+            var gameRule = (ChaserGameRule)GameRule;
+            CurrentChaser = (long)(gameRule.Chaser?.Account.Id ?? 0);
+            //CurrentChaserTarget = 0;
+            //Unk6 = 1;
+
+            w.Write(CurrentChaser);
+            w.Write(CurrentChaserTarget);
+
+            w.Write(Unk3);
+            w.Write(Unk4);
+            w.Write(Unk5);
+            w.Write(Unk6);
+
+            w.Write(Unk7.Count);
+            w.Write(Unk7);
+
+            w.Write(Unk8.Count);
+            w.Write(Unk8);
+
+            w.Write(Unk9.Count);
+            w.Write(Unk9);
+        }
+    }
+
+    internal class ChaserPlayerRecord : PlayerRecord
+    {
+        public override uint TotalScore => GetTotalScore();
+
+        public uint Unk1 { get; set; }
+        public uint Unk2 { get; set; }
+        public uint Unk3 { get; set; }
+        public uint Unk4 { get; set; }
+        public uint BonusKills { get; set; }
+        public uint Unk5 { get; set; } //Increases points
+        public uint Unk6 { get; set; } //Increases points
+        public uint Unk7 { get; set; } //Increases points and did at some point instanced a second chaser
+        public uint Unk8 { get; set; } //Increases points
+        public uint Wins { get; set; } //Wins
+        public uint Survived { get; set; }
+        public uint Unk9 { get; set; } //Increases points
+        public uint Unk10 { get; set; } //Increases points 
+        public uint ChaserCount { get; set; }
+        public uint Unk11 { get; set; } //Increases points
+        public uint Unk12 { get; set; }
+        public uint Unk13 { get; set; }
+        public uint Unk14 { get; set; }
+        public uint Unk15 { get; set; }
+        public uint Unk16 { get; set; }
+
+        public float Unk17 { get; set; }
+        public float Unk18 { get; set; }
+        public float Unk19 { get; set; }
+        public float Unk20 { get; set; }
+
+        public byte Unk21 { get; set; }
+
+        public ChaserPlayerRecord(Player plr)
+            : base(plr)
+        { }
+
+        public override void Serialize(BinaryWriter w, bool isResult)
+        {
+            base.Serialize(w, isResult);
+
+            w.Write(TotalScore);
+            w.Write(Unk2);
+            w.Write(Unk3);
+            w.Write(Unk4);
+            w.Write(Kills);
+            w.Write(BonusKills);
+            w.Write(Unk5);
+            w.Write(Unk6);
+            w.Write(Unk7);
+            w.Write(Unk8);
+            w.Write(Wins);
+            w.Write(Survived);
+            w.Write(Unk9);
+            w.Write(Unk10);
+            w.Write(ChaserCount);
+            w.Write(Unk11);
+            w.Write(Unk12);
+            w.Write(Unk13);
+            w.Write(Unk14);
+            w.Write(Unk15);
+            w.Write(Unk16);
+
+            w.Write(Unk17);
+            w.Write(Unk18);
+            w.Write(Unk19);
+            w.Write(Unk20);
+
+            w.Write(Unk21);
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            Unk1 = 0;
+            Unk2 = 0;
+            Unk3 = 0;
+            Unk4 = 0;
+            Kills = 0;
+            BonusKills = 0;
+            Unk5 = 0;
+            Unk6 = 0;
+            Unk7 = 0;
+            Unk8 = 0;
+            Wins = 0;
+            Survived = 0;
+            Unk9 = 0;
+            Unk10 = 0;
+            ChaserCount = 0;
+            Unk11 = 0;
+            Unk12 = 0;
+            Unk13 = 0;
+            Unk14 = 0;
+            Unk15 = 0;
+            Unk16 = 0;
+            Unk17 = 0;
+            Unk18 = 0;
+            Unk19 = 0;
+            Unk20 = 0;
+            Unk21 = 0;
+        }
+
+        private uint GetTotalScore()
+        {
+            return Kills * 2 +
+                BonusKills * 4 +
+                Wins * 5 +
+                Survived * 10;
+        }
+    }
+}

--- a/src/Game/Game/GameRules/GameRuleBase.cs
+++ b/src/Game/Game/GameRules/GameRuleBase.cs
@@ -155,6 +155,7 @@ namespace Netsphere.Game.GameRules
             switch (transition.Destination)
             {
                 case GameRuleState.FirstHalf:
+                case GameRuleState.FullGame:
                     GameTime = TimeSpan.Zero;
                     foreach (var team in Room.TeamManager.Values)
                         team.Score = 0;
@@ -176,8 +177,9 @@ namespace Netsphere.Game.GameRules
 
                     Room.BroadcastBriefing();
                     Room.Broadcast(new SChangeStateAckMessage(GameState.Playing));
-                    Room.Broadcast(new SChangeSubStateAckMessage(GameTimeState.FirstHalf));
-                    break;
+                    if (transition.Destination == GameRuleState.FirstHalf)
+                        Room.Broadcast(new SChangeSubStateAckMessage(GameTimeState.FirstHalf));
+                        break;
 
                 case GameRuleState.HalfTime:
                     Room.Broadcast(new SChangeSubStateAckMessage(GameTimeState.HalfTime));


### PR DESCRIPTION
This will fix the timer for those who joined the game with the master and those who started the game later if they were in the room (if they did not click ready and pressed start after).

It won't display the time properly for those who joined mid-game in the score tab (the yellow timer) but the .seqs (effects) will trigger properly anyway.

I don't know how it manages the time for people that joins mid-game  but at least hopefully this will help a bit.

[GameRuleBase.cs]
Added GameRuleState.FullGame to the transition.Destination switch.
----------------------------------------------------------------------

When using FullGame instead of First Half, line 181 won't trigger ( Room.Broadcast(new SChangeSubStateAckMessage(GameTimeState.FirstHalf))) which is the responsible of showing half of the time and triggering the time .seqs not properly.

What this does:
+ .seqs (countdown sounds/effects) will trigger properly.
+ Everyone that starts with the master (people who pressed ready) AND people who joins the match after the game has started, but were in the room when it began (as in, you were in the room but did not press ready, and joined after) will have the proper time displayed in the score tab.
- This won't fix the timer for the people who join mid-game, but the .seqs will trigger properly for them regardless (It will only display wrong in the score tab).

[BattleRoyalGameRule.cs]
Switched FirstHalf with FullGame  
------------------------------------------------------------------------

This could also be applied to Chaser game mode, but since the game mode is still broken i only implemented it in BR

Note: apparently the commit fucked up in the BR .cs but what i basically did is to switch FirstHalf with FullGame in the BattleRoyalGameRule constructor and in the update loop