### PR TITLE
Fix tutorial

### DIFF
--- a/src/Game/Network/Services/ChannelService.cs
+++ b/src/Game/Network/Services/ChannelService.cs
@@ -150,6 +150,21 @@ namespace Netsphere.Network.Services
             return session.SendAsync(new SServerResultInfoAckMessage(ServerResult.QuickJoinFailed));
         }
 
+        [MessageHandler(typeof(CEnableAccountStatusAckMessage))]
+        public Task EnableAccountStatus(GameSession session, CEnableAccountStatusAckMessage message)
+        {
+            var plr = session.Player;
+
+            if(plr.TutorialState != 2 && Config.Instance.Game.EnableTutorial)
+            {
+                plr.PEN += 5000;
+                plr.TutorialState = message.TutorialState;
+                session.SendAsync(new SRefreshCashInfoAckMessage { PEN = plr.PEN, AP = plr.AP });
+            }
+
+            return Task.CompletedTask;
+        }
+
         [MessageHandler(typeof(CTaskRequestReqMessage))]
         public Task TaskRequestReq(GameSession session, CTaskRequestReqMessage message)
         {

--- a/src/Game/Network/Services/RoomService.cs
+++ b/src/Game/Network/Services/RoomService.cs
@@ -230,6 +230,10 @@ namespace Netsphere.Network.Services
         {
             var plr = session.Player;
 
+            // For some reason, when a Player ends the tutorial this function is run without a Room set even though
+            // the RegisterRule for "CEventMessageReqMessage" has the "MustBeInRoom" predicate...
+            if(plr.Room == null) return;
+
             plr.Room.Broadcast(new SEventMessageAckMessage(message.Event, session.Player.Account.Id, message.Unk1, message.Value, ""));
             //if (message.Event == GameEventMessage.BallReset && plr == plr.Room.Host)
             //{

--- a/src/Netsphere.Network/Message/Game/C2S.cs
+++ b/src/Netsphere.Network/Message/Game/C2S.cs
@@ -501,6 +501,6 @@ namespace Netsphere.Network.Message.Game
     public class CEnableAccountStatusAckMessage : IGameMessage
     {
         [BlubMember(0)]
-        public uint Unk { get; set; }
+        public byte TutorialState { get; set; }
     }
 }


### PR DESCRIPTION
This fixes the client crash that happens when a user finishes the tutorial.  
  
I have no idea if CEnableAccountStatusAckMessage is only used for this, but the (former) Unk equals 2 when you finish the tutorial, so it works very well like this.